### PR TITLE
publishLocal to be mentioned?

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ run cluster-seed
 ```bash
 git checkout 6ba398391
 sbt universal:stage
+sbt universal:publishLocal
 cd target/universal/stage/bin
 ./csw-cluster-seed --clusterPort=3552
 ```


### PR DESCRIPTION
I think sbt universal:publishLocal should be executed after the staging. Is it understood or should we keep it in README ?